### PR TITLE
Make $ini [ordered] in PsIni.psm1

### DIFF
--- a/PsIni.psm1
+++ b/PsIni.psm1
@@ -74,7 +74,7 @@ Function Get-IniContent {
     {
         Write-Verbose "$($MyInvocation.MyCommand.Name):: Processing file: $Filepath"
 
-        $ini = @{}
+        $ini = [ordered]@{}
         switch -regex -file $FilePath
         {
             "^\[(.+)\]$" # Section
@@ -190,9 +190,9 @@ Function Out-IniFile {
         Saves the content of the $IniVar Hashtable to the INI File c:\myinifile.ini and saves the file into $file
 
     .Example
-        $Category1 = @{“Key1”=”Value1”;”Key2”=”Value2”}
-        $Category2 = @{“Key1”=”Value1”;”Key2”=”Value2”}
-        $NewINIContent = @{“Category1”=$Category1;”Category2”=$Category2}
+        $Category1 = @{â€œKey1â€=â€Value1â€;â€Key2â€=â€Value2â€}
+        $Category2 = @{â€œKey1â€=â€Value1â€;â€Key2â€=â€Value2â€}
+        $NewINIContent = @{â€œCategory1â€=$Category1;â€Category2â€=$Category2}
         Out-IniFile -InputObject $NewINIContent -FilePath "C:\MyNewFile.ini"
         -----------
         Description
@@ -210,7 +210,7 @@ Function Out-IniFile {
         [string]$Encoding = "Unicode",
 
         [ValidateNotNullOrEmpty()]
-        [ValidatePattern('^[a-zA-Z0-9öäüÜÖÄ!§$%&\(\)=;_\''+#\-\.,\`²³\{\[\]\}]{1,255}$')]
+        [ValidatePattern('^[a-zA-Z0-9Ã¶Ã¤Ã¼ÃœÃ–Ã„!Â§$%&\(\)=;_\''+#\-\.,\`Â²Â³\{\[\]\}]{1,255}$')]
         [Parameter(Mandatory=$True)]
         [string]$FilePath,
 


### PR DESCRIPTION
This makes $ini [ordered] so that the order of entries in the ini file is preserved in the hashtable.