### PR TITLE
some good improvements to Get-IniContent.ps1

### DIFF
--- a/PSIni/Functions/Get-IniContent.ps1
+++ b/PSIni/Functions/Get-IniContent.ps1
@@ -88,7 +88,9 @@ Function Get-IniContent {
 
         Write-Verbose "$($MyInvocation.MyCommand.Name):: Function started"
 
-        $commentRegex = "^([$($CommentChar -join '')].*)$"
+        $commentRegex = "^\s*([$($CommentChar -join '')].*)$"
+        $sectionRegex = "^\s*\[(.+)\]\s*$"
+        $keyRegex     = "^\s*(.+?)\s*=\s*(['`"]?)(.*)\2\s*$"
 
         Write-Debug ("commentRegex is {0}." -f $commentRegex)
     }
@@ -97,6 +99,7 @@ Function Get-IniContent {
         Write-Verbose "$($MyInvocation.MyCommand.Name):: Processing file: $Filepath"
 
         $ini = New-Object System.Collections.Specialized.OrderedDictionary([System.StringComparer]::OrdinalIgnoreCase)
+        #$ini = @{}
 
         if (!(Test-Path $Filepath)) {
             Write-Verbose ("Warning: `"{0}`" was not found." -f $Filepath)
@@ -105,7 +108,7 @@ Function Get-IniContent {
 
         $commentCount = 0
         switch -regex -file $FilePath {
-            "^\s*\[(.+)\]\s*$" {
+            $sectionRegex {
                 # Section
                 $section = $matches[1]
                 Write-Verbose "$($MyInvocation.MyCommand.Name):: Adding section : $section"
@@ -133,13 +136,13 @@ Function Get-IniContent {
 
                 continue
             }
-            "(.+?)\s*=\s*(.*)" {
+            $keyRegex {
                 # Key
                 if (!(test-path "variable:local:section")) {
                     $section = $script:NoSection
                     $ini[$section] = New-Object System.Collections.Specialized.OrderedDictionary([System.StringComparer]::OrdinalIgnoreCase)
                 }
-                $name, $value = $matches[1..2]
+                $name, $value = $matches[1, 3]
                 Write-Verbose "$($MyInvocation.MyCommand.Name):: Adding key $name with value: $value"
                 $ini[$section][$name] = $value
                 continue


### PR DESCRIPTION
Hi,

I'd like to use some parts of your project with some improvements that could be useful for others.

-- allow whitespaces in the beginning of comments
-- allow whitespaces around sections and key/value/ pairs
-- allow quotation for values
-- move the important regexp settings out of the Process block