### PR TITLE
Read Multiple Values for Common Key into Array

### DIFF
--- a/PSIni/Functions/Get-IniContent.ps1
+++ b/PSIni/Functions/Get-IniContent.ps1
@@ -141,14 +141,10 @@ Function Get-IniContent {
                 }
                 $name, $value = $matches[1..2]
                 Write-Verbose "$($MyInvocation.MyCommand.Name):: Adding key $name with value: $value"
-                if ($ini[$section][$name] -is [string]) {
-                    $ini[$section][$name] = $ini[$section][$name], $value
+                if (-not $ini[$section][$name]) {
+                    $ini[$section][$name] = @($value)
                 } else {
-                    if($ini[$section][$name] -is [array]) {
                         $ini[$section][$name] += $value
-                    } else {
-                        $ini[$section][$name] = $value
-                    }
                 }
                 continue
             }

--- a/PSIni/Functions/Get-IniContent.ps1
+++ b/PSIni/Functions/Get-IniContent.ps1
@@ -141,7 +141,15 @@ Function Get-IniContent {
                 }
                 $name, $value = $matches[1..2]
                 Write-Verbose "$($MyInvocation.MyCommand.Name):: Adding key $name with value: $value"
-                $ini[$section][$name] = $value
+                if ($ini[$section][$name] -is [string]) {
+                    $ini[$section][$name] = $ini[$section][$name], $value
+                } else {
+                    if($ini[$section][$name] -is [array]) {
+                        $ini[$section][$name] += $value
+                    } else {
+                        $ini[$section][$name] = $value
+                    }
+                }
                 continue
             }
         }

--- a/PSIni/Functions/Out-IniFile.ps1
+++ b/PSIni/Functions/Out-IniFile.ps1
@@ -154,7 +154,7 @@ Function Out-IniFile {
                     else {
                         Write-Verbose "$($MyInvocation.MyCommand.Name):: Writing key: $key"
                         $InputObject[$key] |
-                            ForEach-Object { "$key$delimiter$_)" } |
+                            ForEach-Object { "$key$delimiter$_" } |
                             Add-Content -Encoding $Encoding -Path $Path
                     }
                 }

--- a/PSIni/Functions/Out-IniFile.ps1
+++ b/PSIni/Functions/Out-IniFile.ps1
@@ -153,7 +153,13 @@ Function Out-IniFile {
                     }
                     else {
                         Write-Verbose "$($MyInvocation.MyCommand.Name):: Writing key: $key"
-                        Add-Content -Value "$key$delimiter$($InputObject[$key])" -Encoding $Encoding -Path $Path
+                        if ($InputObject[$key] -is [string]) {
+                            Add-Content -Value "$key$delimiter$($InputObject[$key])" -Encoding $Encoding -Path $Path
+                        } else {
+                            Foreach ($value in $InputObject[$key]) {
+                                Add-Content -Value "$key$delimiter$($value)" -Encoding $Encoding -Path $Path
+                            }
+                        }
                     }
                 }
             }
@@ -194,13 +200,13 @@ Function Out-IniFile {
                 Add-Content -Value "$i$delimiter$($InputObject[$i])" @parameters
 
             }
-            elseif ($i -eq $script:NoSection) {
-                #Key value pair of NoSection
-                Out-Keys $InputObject[$i] `
-                    @parameters `
-                    -Delimiter $delimiter `
-                    -MyInvocation $MyInvocation
-            }
+#            elseif ($i -eq $script:NoSection) {
+#                #Key value pair of NoSection
+#                Out-Keys $InputObject[$i] `
+#                    @parameters `
+#                    -Delimiter $delimiter `
+#                    -MyInvocation $MyInvocation
+#            }
             else {
                 #Sections
                 Write-Verbose "$($MyInvocation.MyCommand.Name):: Writing Section: [$i]"

--- a/PSIni/Functions/Out-IniFile.ps1
+++ b/PSIni/Functions/Out-IniFile.ps1
@@ -153,13 +153,9 @@ Function Out-IniFile {
                     }
                     else {
                         Write-Verbose "$($MyInvocation.MyCommand.Name):: Writing key: $key"
-                        if ($InputObject[$key] -is [string]) {
-                            Add-Content -Value "$key$delimiter$($InputObject[$key])" -Encoding $Encoding -Path $Path
-                        } else {
-                            Foreach ($value in $InputObject[$key]) {
-                                Add-Content -Value "$key$delimiter$($value)" -Encoding $Encoding -Path $Path
-                            }
-                        }
+                        $InputObject[$key] |
+                            ForEach-Object { "$key$delimiter$_)" } |
+                            Add-Content -Encoding $Encoding -Path $Path
                     }
                 }
             }

--- a/PSIni/Functions/Out-IniFile.ps1
+++ b/PSIni/Functions/Out-IniFile.ps1
@@ -200,13 +200,13 @@ Function Out-IniFile {
                 Add-Content -Value "$i$delimiter$($InputObject[$i])" @parameters
 
             }
-#            elseif ($i -eq $script:NoSection) {
-#                #Key value pair of NoSection
-#                Out-Keys $InputObject[$i] `
-#                    @parameters `
-#                    -Delimiter $delimiter `
-#                    -MyInvocation $MyInvocation
-#            }
+            elseif ($i -eq $script:NoSection) {
+                #Key value pair of NoSection
+                Out-Keys $InputObject[$i] `
+                    @parameters `
+                    -Delimiter $delimiter `
+                    -MyInvocation $MyInvocation
+            }
             else {
                 #Sections
                 Write-Verbose "$($MyInvocation.MyCommand.Name):: Writing Section: [$i]"

--- a/Tests/PsIni.Tests.ps1
+++ b/Tests/PsIni.Tests.ps1
@@ -40,7 +40,7 @@ Describe "PsIni functionality" {
     $dictIn["Category1"]["Key1"] = "Value1"
     $dictIn["Category1"]["Key2"] = "Value2"
     $dictIn["Category2"] = New-Object System.Collections.Specialized.OrderedDictionary([System.StringComparer]::OrdinalIgnoreCase)
-    $dictIn["Category2"]["Key3"] = "Value3"
+    $dictIn["Category2"]["Key3"] = @("Value3.1", "Value3.2")
     $dictIn["Category2"]["Key4"] = "Value4"
 
     Context "Load Module" {
@@ -69,7 +69,7 @@ Describe "PsIni functionality" {
         # assert
         It "content matches expected value" {
 
-            $content = "[Category1]`r`nKey1=value1`r`nKey2=Value2`r`n[Category2]`r`nKey3=Value3`r`nKey4=Value4`r`n"
+            $content = "[Category1]`r`nKey1=value1`r`nKey2=Value2`r`n[Category2]`r`nKey3=Value3.1`r`nKey3=Value3.2`r`nKey4=Value4`r`n"
 
             Get-Content $iniFile -Raw | Should Be $content
 
@@ -91,7 +91,7 @@ Describe "PsIni functionality" {
         # assert
         It "content matches expected value" {
 
-            $content = "[Category1]`r`nKey1=value1`r`nKey2=Value2`r`n`r`n[Category2]`r`nKey3=Value3`r`nKey4=Value4`r`n"
+            $content = "[Category1]`r`nKey1=value1`r`nKey2=Value2`r`n`r`n[Category2]`r`nKey3=Value3.1`r`nKey3=Value3.2`r`nKey4=Value4`r`n"
 
             Get-Content $iniFile -Raw | Should Be $content
 

--- a/Tests/PsIni.Tests.ps1
+++ b/Tests/PsIni.Tests.ps1
@@ -40,7 +40,7 @@ Describe "PsIni functionality" {
     $dictIn["Category1"]["Key1"] = "Value1"
     $dictIn["Category1"]["Key2"] = "Value2"
     $dictIn["Category2"] = New-Object System.Collections.Specialized.OrderedDictionary([System.StringComparer]::OrdinalIgnoreCase)
-    $dictIn["Category2"]["Key3"] = @("Value3.1", "Value3.2")
+    $dictIn["Category2"]["Key3"] = @("Value3.1", "Value3.2", "Value3.3")
     $dictIn["Category2"]["Key4"] = "Value4"
 
     Context "Load Module" {
@@ -69,7 +69,7 @@ Describe "PsIni functionality" {
         # assert
         It "content matches expected value" {
 
-            $content = "[Category1]`r`nKey1=value1`r`nKey2=Value2`r`n[Category2]`r`nKey3=Value3.1`r`nKey3=Value3.2`r`nKey4=Value4`r`n"
+            $content = "[Category1]`r`nKey1=value1`r`nKey2=Value2`r`n[Category2]`r`nKey3=Value3.1`r`nKey3=Value3.2`r`nKey3=Value3.3`r`nKey4=Value4`r`n"
 
             Get-Content $iniFile -Raw | Should Be $content
 
@@ -91,7 +91,7 @@ Describe "PsIni functionality" {
         # assert
         It "content matches expected value" {
 
-            $content = "[Category1]`r`nKey1=value1`r`nKey2=Value2`r`n`r`n[Category2]`r`nKey3=Value3.1`r`nKey3=Value3.2`r`nKey4=Value4`r`n"
+            $content = "[Category1]`r`nKey1=value1`r`nKey2=Value2`r`n`r`n[Category2]`r`nKey3=Value3.1`r`nKey3=Value3.2`r`nKey3=Value3.3`r`nKey4=Value4`r`n"
 
             Get-Content $iniFile -Raw | Should Be $content
 


### PR DESCRIPTION
Dear lipkau,

thank you very much for the great tool. When I wanted to use it, I encountered the problem that the ini files I have to modify contain several keys in a section with the same name. Therefore, I'd like to propose to read in those entries as an array.

Please consider adding this feature. This pullrequest is a simple approach to solve that problem. Probably, Set-IniContent and Out-IniFile needs adaption, too. I think you will know best which adjustments need to be made. However, if you are not able to do the necessary changes, please let me know what is required.

Kind regards

Konstantin