### PR TITLE
Fix random Add-Content : Stream was not readable

### DIFF
--- a/PSIni/Functions/Out-IniFile.ps1
+++ b/PSIni/Functions/Out-IniFile.ps1
@@ -1,3 +1,4 @@
+Set-StrictMode -Version Latest
 Function Out-IniFile {
     <#
     .Synopsis

--- a/PSIni/Functions/Out-IniFile.ps1
+++ b/PSIni/Functions/Out-IniFile.ps1
@@ -1,4 +1,3 @@
-﻿Set-StrictMode -Version Latest
 Function Out-IniFile {
     <#
     .Synopsis
@@ -133,7 +132,7 @@ Function Out-IniFile {
                 [ValidateScript( {Test-Path $_ -IsValid})]
                 [Parameter( Mandatory, ValueFromPipelineByPropertyName )]
                 [string]
-                $Path,
+                $FilePath,
 
                 [Parameter( Mandatory )]
                 $Delimiter,
@@ -149,13 +148,13 @@ Function Out-IniFile {
                 Foreach ($key in $InputObject.get_keys()) {
                     if ($key -match "^Comment\d+") {
                         Write-Verbose "$($MyInvocation.MyCommand.Name):: Writing comment: $key"
-                        Add-Content -Value "$($InputObject[$key])" -Encoding $Encoding -Path $Path
+                        "$($InputObject[$key])" | Out-File -Encoding $Encoding -FilePath $FilePath -Append
                     }
                     else {
                         Write-Verbose "$($MyInvocation.MyCommand.Name):: Writing key: $key"
                         $InputObject[$key] |
                             ForEach-Object { "$key$delimiter$_" } |
-                            Add-Content -Encoding $Encoding -Path $Path
+                            Out-File -Encoding $Encoding -FilePath $FilePath -Append
                     }
                 }
             }
@@ -169,7 +168,7 @@ Function Out-IniFile {
         # Splatting Parameters
         $parameters = @{
             Encoding = $Encoding;
-            Path     = $FilePath
+            FilePath = $FilePath
         }
 
     }
@@ -193,7 +192,7 @@ Function Out-IniFile {
             if (!($InputObject[$i].GetType().GetInterface('IDictionary'))) {
                 #Key value pair
                 Write-Verbose "$($MyInvocation.MyCommand.Name):: Writing key: $i"
-                Add-Content -Value "$i$delimiter$($InputObject[$i])" @parameters
+                "$i$delimiter$($InputObject[$i])" | Out-File -Append @parameters
 
             }
             elseif ($i -eq $script:NoSection) {
@@ -208,7 +207,7 @@ Function Out-IniFile {
                 Write-Verbose "$($MyInvocation.MyCommand.Name):: Writing Section: [$i]"
 
                 # Only write section, if it is not a dummy ($script:NoSection)
-                if ($i -ne $script:NoSection) { Add-Content -Value "$extraLF[$i]" @parameters }
+                if ($i -ne $script:NoSection) { "$extraLF[$i]"  | Out-File -Append @parameters }
                 if ($Pretty) {
                     $extraLF = "`r`n"
                 }

--- a/PSIni/Functions/Out-IniFile.ps1
+++ b/PSIni/Functions/Out-IniFile.ps1
@@ -131,6 +131,7 @@ Function Out-IniFile {
                 [ValidateNotNullOrEmpty()]
                 [ValidateScript( {Test-Path $_ -IsValid})]
                 [Parameter( Mandatory, ValueFromPipelineByPropertyName )]
+                [Alias("Path")]
                 [string]
                 $FilePath,
 


### PR DESCRIPTION
We met some random exceptions while using PsIni. Googling for a while, I found that many people have these exceptions with Add-Content and Set-Content. Replacing it with piping the string into Out-File -Append, the exception does not appear again.

Typical exception :

    Add-Content : Stream was not readable.
    At C:\Users\...\PsIni\2.0.7\Functions\Out-IniFile.ps1:158 char:29
    + ...                           Add-Content -Encoding $Encoding -Path $Path
    +                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        + CategoryInfo          : InvalidArgument: (C:\...:String) [Add-Content], ArgumentException
        + FullyQualifiedErrorId : GetContentWriterArgumentError,Microsoft.PowerShell.Commands.AddContentCommand