### PR TITLE
Added Parameter -Encoding to extend support of codepages

### DIFF
--- a/PSIni/Functions/Get-IniContent.ps1
+++ b/PSIni/Functions/Get-IniContent.ps1
@@ -111,9 +111,13 @@
         }
 
         $commentCount = 0
+	Write-Verbose "$($MyInvocation.MyCommand.Name):: Read file ($FilePath) with Encoding($Encoding)"
 	$fileContent = Get-Content -Path $FilePath -Encoding $Encoding
+        $lineCount = 0
 	foreach ($line in $fileContent) {
-	  switch -regex $line {
+	  $lineCount++
+          Write-Verbose "$($MyInvocation.MyCommand.Name):: Line($lineCount) : $line"
+	  switch -regex ($line) {
             $sectionRegex {
                 # Section
                 $section = $matches[1]

--- a/PSIni/Functions/Get-IniContent.ps1
+++ b/PSIni/Functions/Get-IniContent.ps1
@@ -74,7 +74,12 @@
 
         # Remove lines determined to be comments from the resulting dictionary.
         [Switch]
-        $IgnoreComments
+        $IgnoreComments,
+        
+        # Encoding used to read file content
+        [ValidateSet('ASCII', 'BigEndianUnicode', 'OEM', 'Unicode', 'UTF7', 'UTF8', 'UTF8BOM', 'UTF8NoBOM', 'UTF32')]
+        [String] 
+        $Encoding = 'UTF8NoBOM'
     )
 
     Begin {
@@ -106,7 +111,9 @@
         }
 
         $commentCount = 0
-        switch -regex -file $FilePath {
+	$fileContent = Get-Content -Path $FilePath -Encoding $Encoding
+	foreach ($line in $fileContent) {
+	  switch -regex $line {
             $sectionRegex {
                 # Section
                 $section = $matches[1]
@@ -159,6 +166,7 @@
                 continue
             }
         }
+	}
         Write-Verbose "$($MyInvocation.MyCommand.Name):: Finished Processing file: $FilePath"
         Write-Output $ini
     }

--- a/PSIni/Functions/Out-IniFile.ps1
+++ b/PSIni/Functions/Out-IniFile.ps1
@@ -70,7 +70,7 @@ Function Out-IniFile {
         # -- Unicode:  Encodes in UTF-16 format using the little-endian byte order.
         # -- UTF7:   Encodes in UTF-7 format.
         # -- UTF8:  Encodes in UTF-8 format.
-        [ValidateSet("Unicode", "UTF7", "UTF8", "ASCII", "BigEndianUnicode", "Byte", "String")]
+        [ValidateSet("Default", "Unicode", "UTF7", "UTF8", "ASCII", "BigEndianUnicode", "Byte", "String")]
         [Parameter()]
         [String]
         $Encoding = "UTF8",
@@ -123,7 +123,7 @@ Function Out-IniFile {
                 [System.Collections.IDictionary]
                 $InputObject,
 
-                [ValidateSet("Unicode", "UTF7", "UTF8", "ASCII", "BigEndianUnicode", "Byte", "String")]
+                [ValidateSet("Default", "Unicode", "UTF7", "UTF8", "ASCII", "BigEndianUnicode", "Byte", "String")]
                 [Parameter( Mandatory )]
                 [string]
                 $Encoding = "UTF8",

--- a/PSIni/Functions/Set-IniContent.ps1
+++ b/PSIni/Functions/Set-IniContent.ps1
@@ -96,7 +96,7 @@ Function Set-IniContent {
         
         # Encoding used to read file content
         [Parameter( Mandatory = $false, ParameterSetName = "File")]
-        [ValidateSet('ASCII', 'BigEndianUnicode', 'OEM', 'Unicode', 'UTF7', 'UTF8', 'UTF8BOM', 'UTF8NoBOM', 'UTF32')]
+        [ValidateSet('Default', 'ASCII', 'BigEndianUnicode', 'OEM', 'Unicode', 'UTF7', 'UTF8', 'UTF8BOM', 'UTF8NoBOM', 'UTF32')]
         [String] 
         $Encoding = 'UTF8NoBOM'
     )

--- a/PSIni/Functions/Set-IniContent.ps1
+++ b/PSIni/Functions/Set-IniContent.ps1
@@ -92,7 +92,13 @@ Function Set-IniContent {
         [Parameter( ParameterSetName = "Object" )]
         [ValidateNotNullOrEmpty()]
         [String[]]
-        $Sections
+        $Sections,
+        
+        # Encoding used to read file content
+        [Parameter( Mandatory = $false, ParameterSetName = "File")]
+        [ValidateSet('ASCII', 'BigEndianUnicode', 'OEM', 'Unicode', 'UTF7', 'UTF8', 'UTF8BOM', 'UTF8NoBOM', 'UTF32')]
+        [String] 
+        $Encoding = 'UTF8NoBOM'
     )
 
     Begin {
@@ -122,7 +128,7 @@ Function Set-IniContent {
     # Update the specified keys in the list, either in the specified section or in all sections.
     Process {
         # Get the ini from either a file or object passed in.
-        if ($PSCmdlet.ParameterSetName -eq 'File') { $content = Get-IniContent $FilePath }
+        if ($PSCmdlet.ParameterSetName -eq 'File') { $content = Get-IniContent $FilePath -Encoding $Encoding }
         if ($PSCmdlet.ParameterSetName -eq 'Object') { $content = $InputObject }
 
         # Specific section(s) were requested.


### PR DESCRIPTION
PsIni should be able to handle encoding of ini-files. Therefore I have added -Encoding parameter to some module-files and parameter validation rules to known encoding strings.