### PR TITLE
Safe first value in list before overwriting

### DIFF
--- a/PSIni/Functions/Get-IniContent.ps1
+++ b/PSIni/Functions/Get-IniContent.ps1
@@ -148,8 +148,9 @@
                 }
                 else {
                     if ($ini[$section][$name] -is [string]) {
+                        $first = $ini[$section][$name]
                         $ini[$section][$name] = [System.Collections.ArrayList]::new()
-                        $ini[$section][$name].Add($ini[$section][$name]) | Out-Null
+                        $ini[$section][$name].Add($first) | Out-Null
                         $ini[$section][$name].Add($value) | Out-Null
                     }
                     else {


### PR DESCRIPTION
- Bugfix: Fixes https://github.com/lipkau/PsIni/issues/57
- If a key already exist in table, its values are stored as
  System.Collections.ArrayList. However, System.Collections.ArrayList
  overwrites the first value before it has been added to the list
  itself.