### PR TITLE
Fix Duplicate Keys causing "redundant" string/arraylist keys

### DIFF
--- a/PSIni/Functions/Get-IniContent.ps1
+++ b/PSIni/Functions/Get-IniContent.ps1
@@ -148,8 +148,10 @@
                 }
                 else {
                     if ($ini[$section][$name] -is [string]) {
+                        $initialValue = $ini[$section][$name]
+                        $ini[$section].Remove($name)
                         $ini[$section][$name] = [System.Collections.ArrayList]::new()
-                        $ini[$section][$name].Add($ini[$section][$name]) | Out-Null
+                        $ini[$section][$name].Add($initialValue) | Out-Null
                         $ini[$section][$name].Add($value) | Out-Null
                     }
                     else {


### PR DESCRIPTION
The old way added a new arraylist, but never removed the old item - causing duplicates and being really confusing when you printed it through Out-INIFile 

https://i.imgur.com/3W7zvYY.png
https://i.imgur.com/lkiyyBO.png