### PR TITLE
Add -IgnoreEmptySection parameter to Get-IniContent

### DIFF
--- a/PSIni/Public/Import-Ini.ps1
+++ b/PSIni/Public/Import-Ini.ps1
@@ -58,7 +58,11 @@ function Import-Ini {
 
         # Remove lines determined to be comments from the resulting dictionary.
         [Switch]
-        $IgnoreComments
+        $IgnoreComments,
+
+        # Remove sections without any key
+        [Switch]
+        $IgnoreEmptySections
     )
 
     begin {
@@ -149,7 +153,18 @@ function Import-Ini {
                     continue
                 }
             }
-
+            if($IgnoreEmptySections){
+                $ToRemove = [System.Collections.ArrayList]@()
+                foreach($Section in $ini.Keys){
+                    if(($ini[$Section]).Count -eq 0){
+                        $null = $ToRemove.Add($Section)
+                    }
+                }
+                foreach($Section in $ToRemove){
+                    Write-Verbose "$($MyInvocation.MyCommand.Name):: Removing empty section $Section"
+                    $null = $ini.Remove($Section)
+                }
+            }
             $ini
         }
     }

--- a/Tests/ConvertFrom-Ini.Unit.Tests.ps1
+++ b/Tests/ConvertFrom-Ini.Unit.Tests.ps1
@@ -50,7 +50,7 @@ Describe "ConvertFrom-Ini" -Tag "Unit" {
         It "has the ini sections and keys without a section as root properties" {
             $convertedObject = ConvertFrom-Ini -Path $iniFile
 
-            ($convertedObject | Get-Member -MemberType *Property).Name | Should -Be @("Arrays", "Comment1", "Key", "NoValues", "Strings")
+            ($convertedObject | Get-Member -MemberType *Property).Name | Should -Be @("Arrays", "Comment1", "EmptySection", "Key", "NoValues", "Strings")
         }
 
         It "treats the value of a key as string" {

--- a/Tests/Import-Ini.Unit.Tests.ps1
+++ b/Tests/Import-Ini.Unit.Tests.ps1
@@ -41,14 +41,14 @@ Describe "Import-Ini" -Tag "Unit" {
         It "loads the sections as expected" {
             $dictOut = Import-Ini -Path $iniFile
 
-            $dictOut.Keys | Should -Be "_", "Strings", "Arrays", "NoValues"
+            $dictOut.Keys | Should -Be "_", "Strings", "Arrays", "NoValues", "EmptySection"
         }
 
         It "uses a module-wide variable for the keys that don't have a section" {
             InModuleScope PsIni { $script:NoSection = "NoName" }
             $dictOut = Import-Ini -Path $iniFile
 
-            $dictOut.Keys | Should -Be "NoName", "Strings", "Arrays", "NoValues"
+            $dictOut.Keys | Should -Be "NoName", "Strings", "Arrays", "NoValues", "EmptySection"
             $dictOut["NoName"]["Key"] | Should -Be "With No Section"
         }
 
@@ -126,6 +126,14 @@ Describe "Import-Ini" -Tag "Unit" {
             $withoutComments["Strings"].Keys | Should -HaveCount 17
             $withComments["Strings"].Keys | Should -Contain "Comment1"
             $withoutComments["Strings"].Keys | Should -Not -Contain "Comment1"
+        }
+
+        It "ignores empty sections when -IgnoreEmptySections is provided" {
+            $withEmptySections = Import-Ini -Path $iniFile
+            $withoutEmptySections = Import-Ini -Path $iniFile -IgnoreEmptySections
+
+            $withEmptySections.Keys | Should -Contain "EmptySection"
+            $withoutEmptySections.Keys | Should -Not -Contain "EmptySection"
         }
 
         It "stores keys without a value" {

--- a/Tests/sample.ini
+++ b/Tests/sample.ini
@@ -28,3 +28,4 @@ String1 = 0,0,0
 [NoValues]
 Key1=
 Key2
+[EmptySection]


### PR DESCRIPTION
Added a new switch parameter for ignoring empty sections in Get-IniContent, similar to the IgnoreComments switch