### PR TITLE
Update Get-IniContent.ps1

### DIFF
--- a/PSIni/Functions/Get-IniContent.ps1
+++ b/PSIni/Functions/Get-IniContent.ps1
@@ -148,8 +148,9 @@
                 }
                 else {
                     if ($ini[$section][$name] -is [string]) {
+                        $firstValue = $ini[$section][$name]
                         $ini[$section][$name] = [System.Collections.ArrayList]::new()
-                        $ini[$section][$name].Add($ini[$section][$name]) | Out-Null
+                        $ini[$section][$name].Add($firstValue) | Out-Null
                         $ini[$section][$name].Add($value) | Out-Null
                     }
                     else {


### PR DESCRIPTION
Original code was creating a nested arraylist on the first item when keynames are the same. Which caused the first items to be doubled up into two lists.

Example:
Routes=8675309
Routes=1234567
Routes=2345678
Routes=3456789

Was read in, but then would output like below when Out-IniFile was called. The desired output would be to match the existing format. What's worse is that the first value in the list is lost. The line Routes=8675309 disappears when writing the file back out.

Routes= System.Collections.ArrayList 1234567 2345678 3456789
Routes=1234567
Routes=2345678
Routes=3456789

