### PR TITLE
[Fix] No longer reading empty lines as keys

### DIFF
--- a/PSIni/Public/Import-Ini.ps1
+++ b/PSIni/Public/Import-Ini.ps1
@@ -87,6 +87,7 @@ function Import-Ini {
 
             if (-not (Test-Path -Path $file)) {
                 Write-Error "Could not find file '$file'"
+                continue
             }
 
             $commentCount = 0
@@ -125,17 +126,19 @@ function Import-Ini {
                         $ini[$section] = New-Object System.Collections.Specialized.OrderedDictionary([System.StringComparer]::OrdinalIgnoreCase)
                     }
                     $name, $value = $matches[1].Trim(), $matches[3].Trim()
-                    Write-Verbose "$($MyInvocation.MyCommand.Name):: Adding key $name with value: $value"
-                    if (-not $ini[$section][$name]) {
-                        $ini[$section][$name] = $value
-                    }
-                    else {
-                        if ($ini[$section][$name] -is [string]) {
-                            $oldValue = $ini[$section][$name]
-                            $ini[$section][$name] = [System.Collections.ArrayList]::new()
-                            $null = $ini[$section][$name].Add($oldValue)
+                    if (-not [string]::IsNullOrWhiteSpace($name)) {
+                        Write-Verbose "$($MyInvocation.MyCommand.Name):: Adding key $name with value: $value"
+                        if (-not $ini[$section][$name]) {
+                            $ini[$section][$name] = $value
                         }
-                        $null = $ini[$section][$name].Add($value)
+                        else {
+                            if ($ini[$section][$name] -is [string]) {
+                                $oldValue = $ini[$section][$name]
+                                $ini[$section][$name] = [System.Collections.ArrayList]::new()
+                                $null = $ini[$section][$name].Add($oldValue)
+                            }
+                            $null = $ini[$section][$name].Add($value)
+                        }
                     }
                     continue
                 }
@@ -147,9 +150,11 @@ function Import-Ini {
                         $section = $script:NoSection
                         $ini[$section] = New-Object System.Collections.Specialized.OrderedDictionary([System.StringComparer]::OrdinalIgnoreCase)
                     }
-                    $name = $_
-                    Write-Verbose "$($MyInvocation.MyCommand.Name):: Adding key $name without a value"
-                    $ini[$section][$name] = $null
+                    $name = $_.Trim()
+                    if (-not [string]::IsNullOrWhiteSpace($name)) {
+                        Write-Verbose "$($MyInvocation.MyCommand.Name):: Adding key $name without a value"
+                        $ini[$section][$name] = $null
+                    }
                     continue
                 }
             }

--- a/PSIni/Public/Import-Ini.ps1
+++ b/PSIni/Public/Import-Ini.ps1
@@ -97,7 +97,7 @@ function Import-Ini {
                     $section = $matches[1]
                     Write-Debug "$($MyInvocation.MyCommand.Name):: Adding section : $section"
                     $ini[$section] = New-Object System.Collections.Specialized.OrderedDictionary([System.StringComparer]::OrdinalIgnoreCase)
-                    $CommentCount = 0
+                    $commentCount = 0
                     continue
                 }
                 $commentRegex {
@@ -108,9 +108,9 @@ function Import-Ini {
                             $ini[$section] = New-Object System.Collections.Specialized.OrderedDictionary([System.StringComparer]::OrdinalIgnoreCase)
                         }
                         $value = $matches[1].Trim()
-                        $CommentCount++
-                        Write-DebugMessage ("Incremented CommentCount is now $CommentCount.")
-                        $name = "Comment$CommentCount"
+                        $commentCount++
+                        Write-DebugMessage ("Incremented commentCount is now $commentCount.")
+                        $name = "Comment$commentCount"
                         Write-Debug "$($MyInvocation.MyCommand.Name):: Adding $name with value: $value"
                         $ini[$section][$name] = $value
                     }

--- a/Tests/Import-Ini.Unit.Tests.ps1
+++ b/Tests/Import-Ini.Unit.Tests.ps1
@@ -147,5 +147,11 @@ Describe "Import-Ini" -Tag "Unit" {
 
             $dictOut["NoValues"]["Key2"] | Should -BeNullOrEmpty
         }
+
+        It "stores keys without a value and trims surrounding whitespace" {
+            $dictOut = Import-Ini -Path $iniFile
+
+            $dictOut["NoValues"]["Key`3"] | Should -BeNullOrEmpty
+        }
     }
 }

--- a/Tests/sample.ini
+++ b/Tests/sample.ini
@@ -28,4 +28,5 @@ String1 = 0,0,0
 [NoValues]
 Key1=
 Key2
+      Key`3     
 [EmptySection]


### PR DESCRIPTION
Import-Ini was taking into consideration empty lines, as key-value pairs.  
This made exporting difficult, as the export function tried to write NoKey & NoValue into the output file.

This commit completely ignores empty lines, as they are of no interest when mapping a config file