### PR TITLE
Changed behaviour of how quotation marks are parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 
 ## [NEXT VERSION] - YYYY-MM-DD
 
-`v4` is a breaking change, as the Commands of the module were refactored and renamed.\
+## v4.0.0 - YYYY-MM-DD
+
+`v4` is a breaking change:
+
+* the commands of the module were refactored and renamed.
+* the behaviour of parsing quotation marks was changes, as per [ADR #95](https://github.com/lipkau/PSIni/discussions/95).
+
 Details on how to upgrade are documented in the [Migrating to PSIni v4](#TODO: )
 
 ### Added

--- a/PSIni/Public/Import-Ini.ps1
+++ b/PSIni/Public/Import-Ini.ps1
@@ -67,9 +67,9 @@
         Write-Verbose "$($MyInvocation.MyCommand.Name):: Function started"
 
         $listOfCommentChars = $CommentChar -join ''
-        $commentRegex = "^\s*[$listOfCommentChars](.*)$"
-        $sectionRegex = "^\s*\[(.+)\]\s*$"
-        $keyRegex = "^\s*([^$listOfCommentChars]+?)\s*=\s*(['`"]?)(.*)\2\s*$"
+        $commentRegex = "^[$listOfCommentChars](.*)$"
+        $sectionRegex = "^\s*\[(.+)\]"
+        $keyRegex = "^([^$listOfCommentChars]+?)=(.*)$"
 
         Write-DebugMessage ("commentRegex is $commentRegex")
         Write-DebugMessage ("sectionRegex is $sectionRegex")
@@ -80,14 +80,14 @@
         foreach ($file in $Path) {
             Write-Verbose "$($MyInvocation.MyCommand.Name):: Processing file: $file"
 
-            $ini = New-Object System.Collections.Specialized.OrderedDictionary([System.StringComparer]::OrdinalIgnoreCase)
-            $section = $null # Section Name
-            $name = $null # Key or Comment Name
-
             if (-not (Test-Path -Path $file)) {
                 Write-Error "Could not find file '$file'"
                 continue
             }
+
+            $ini = New-Object System.Collections.Specialized.OrderedDictionary([System.StringComparer]::OrdinalIgnoreCase)
+            $section = $null # Section Name
+            $name = $null # Key or Comment Name
 
             $commentCount = 0
             switch -regex -file $file {
@@ -124,7 +124,7 @@
                         $section = $script:NoSection
                         $ini[$section] = New-Object System.Collections.Specialized.OrderedDictionary([System.StringComparer]::OrdinalIgnoreCase)
                     }
-                    $name, $value = $matches[1].Trim(), $matches[3].Trim()
+                    $name, $value = $matches[1].Trim(), $matches[2].Trim()
                     if (-not [string]::IsNullOrWhiteSpace($name)) {
                         Write-Verbose "$($MyInvocation.MyCommand.Name):: Adding key $name with value: $value"
                         if (-not $ini[$section][$name]) {

--- a/Tests/Import-Ini.Unit.Tests.ps1
+++ b/Tests/Import-Ini.Unit.Tests.ps1
@@ -78,32 +78,35 @@ Describe "Import-Ini" -Tag "Unit" {
             Import-Ini -Path $iniFile, $iniFile, $iniFile | Should -HaveCount 3
         }
 
-        It "ignores leading and trailing whitespaces from the key and the value" {
+        It "ignores leading and trailing whitespaces from the key and the value" -TestCases @(
+            @{ key = "Key1"; value = "Value1" }
+            @{ key = "Key2"; value = "Value2" }
+            @{ key = "Key3"; value = "Value3" }
+            @{ key = "Key4"; value = "Value4" }
+            @{ key = "Key5"; value = "Value5" }
+            @{ key = "Key6"; value = "Value6" }
+            @{ key = "Key7"; value = "Value7" }
+            @{ key = "Key8"; value = "Value8" }
+            @{ key = "Key9"; value = "Value9" }
+        ) {
             $dictOut = Import-Ini -Path $iniFile
 
-            $dictOut["Strings"]["Key1"] | Should -Be "Value1"
-            $dictOut["Strings"]["Key2"] | Should -Be "Value2"
-            $dictOut["Strings"]["Key3"] | Should -Be "Value3"
-            $dictOut["Strings"]["Key4"] | Should -Be "Value4"
-            $dictOut["Strings"]["Key5"] | Should -Be "Value5"
-            $dictOut["Strings"]["Key6"] | Should -Be "Value6"
-            $dictOut["Strings"]["Key7"] | Should -Be "Value7"
-            $dictOut["Strings"]["Key8"] | Should -Be "Value8"
-            $dictOut["Strings"]["Key9"] | Should -Be "Value9"
+            $dictOut["Strings"][$key] | Should -Be $value
         }
 
-        It "handles quotes in the values as expected" {
+        It "preserves quotes in the values" -TestCases @(
+            @{ key = "Key10"; value = "`"Value10`"" }
+            @{ key = "Key11"; value = "`"`"Value11`"`"" }
+            @{ key = "Key12"; value = "'Value12'" }
+            @{ key = "Key13"; value = "`"'Value13'`"" }
+            @{ key = "Key14"; value = "'`"Value14`"'" }
+            @{ key = "Key15"; value = "`"  Value15  `"" }
+            @{ key = "Key16"; value = "`"  '  Value16  '  `"" }
+            @{ key = "Key17"; value = "Value`"17`"" }
+        ) {
             $dictOut = Import-Ini -Path $iniFile
 
-            $dictOut["Strings"]["Key1"] | Should -Be "Value1"
-            $dictOut["Strings"]["Key10"] | Should -Be "Value10"
-            $dictOut["Strings"]["Key11"] | Should -Be "`"Value11`""
-            $dictOut["Strings"]["Key12"] | Should -Be "Value12"
-            $dictOut["Strings"]["Key13"] | Should -Be "'Value13'"
-            $dictOut["Strings"]["Key14"] | Should -Be "`"Value14`""
-            $dictOut["Strings"]["Key15"] | Should -Be "Value15"
-            $dictOut["Strings"]["Key16"] | Should -Be "'  Value16  '"
-            $dictOut["Strings"]["Key17"] | Should -Be "Value`"17`""
+            $dictOut["Strings"][$key] | Should -Be $value
         }
 
         It "reads lines starting with ';' as comments by default" {


### PR DESCRIPTION
### Description


I have decided to not support the interpretation/stripping of quotation marks.

See ADR #95 for reference
(https://github.com/lipkau/PSIni/discussions/95)

### Motivation and Context

implements #95

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] My code follows the code style of this project.
- [x] I have added Pester Tests that describe what my changes should do.
- [x] I have updated the documentation accordingly.
