### PR TITLE
Added `-InputString` to `Import-Ini`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ Details on how to upgrade are documented in the [Migrating to PSIni v4](#TODO: )
 * Added `ConvertTo-Ini` @lipkau
 * Added `-CommentChar` to `Export-Ini` @lipkau #103
 * Added `-LiteralPath` to `Import-Ini` @lipkau #105
+* Added `-Encoding` to `Import-Ini` @lipkau #111
+* Added `-InputString` to `Import-Ini` @lipkau #111
+  * In order to implement this, a slight performance buff was implemented:\
+    files are now read with [System.IO.File]::ReadAllLines() instead for switch -file\
+    Read more: <https://devdojo.com/hcritter/powershell-performance-test-file-reading>
 
 ### Fixed
 

--- a/Tests/Import-Ini.Unit.Tests.ps1
+++ b/Tests/Import-Ini.Unit.Tests.ps1
@@ -19,11 +19,13 @@ Describe "Import-Ini" -Tag "Unit" {
         }
 
         It "has a parameter '<parameter>' of type '<type>'" -TestCases @(
-            @{ parameter = "Path"; type = "String[]" }
-            @{ parameter = "LiteralPath"; type = "String[]" }
             @{ parameter = "CommentChar"; type = "Char[]" }
+            @{ parameter = "Encoding"; type = "System.Text.Encoding" }
             @{ parameter = "IgnoreComments"; type = "Switch" }
             @{ parameter = "IgnoreEmptySections"; type = "Switch" }
+            @{ parameter = "InputString"; type = "String" }
+            @{ parameter = "LiteralPath"; type = "String[]" }
+            @{ parameter = "Path"; type = "String[]" }
         ) {
             param ($parameter, $type)
             $command | Should -HaveParameter $parameter -Type $type
@@ -31,6 +33,7 @@ Describe "Import-Ini" -Tag "Unit" {
 
         It "parameter '<parameter>' has a default value of '<defaultValue>'" -TestCases @(
             @{ parameter = "CommentChar"; ; defaultValue = '@(";")' }
+            @{ parameter = "Encoding"; defaultValue = "[System.Text.Encoding]::UTF8" }
         ) {
             $command | Should -HaveParameter $parameter -DefaultValue $defaultValue
         }
@@ -211,6 +214,18 @@ Describe "Import-Ini" -Tag "Unit" {
                 $dictOut = Import-Ini -LiteralPath $file1, $file2
 
                 $dictOut | Should -HaveCount 2
+            }
+        }
+
+        Describe "Input from string" {
+            It "Can process a string representation of a INI file" {
+                $ini = "[section]`nkey=value"
+
+                $dictOut = Import-Ini -InputString $ini
+
+                $dictOut.Keys | Should -Contain "section"
+                $dictOut["section"].Keys | Should -Contain "key"
+                $dictOut["section"]["key"] | Should -Be "value"
             }
         }
     }

--- a/Tests/PsIni.Integration.Tests.ps1
+++ b/Tests/PsIni.Integration.Tests.ps1
@@ -8,6 +8,8 @@ Describe "PSIni integration tests" -Tag "Integration" {
         Remove-Module PSIni -ErrorAction SilentlyContinue
         Import-Module $moduleToTest -Force -ErrorAction Stop
 
+        $script:tempFolder = [System.IO.Path]::GetTempPath()
+
         $dictIn = New-Object System.Collections.Specialized.OrderedDictionary([System.StringComparer]::OrdinalIgnoreCase)
         $dictIn["Category1"] = New-Object System.Collections.Specialized.OrderedDictionary([System.StringComparer]::OrdinalIgnoreCase)
         $dictIn["Category1"]["Key1"] = "Value1"
@@ -17,8 +19,11 @@ Describe "PSIni integration tests" -Tag "Integration" {
         $dictIn["Category2"]["Key4"] = "Value4"
     }
     BeforeEach {
-        Export-Ini -InputObject $dictIn -Path "TestDrive:\output.ini" -Force -ErrorAction Stop
-        $script:dictOut = Import-Ini -Path "TestDrive:\output.ini" -ErrorAction Stop
+        Export-Ini -InputObject $dictIn -Path "$tempFolder/output.ini" -Force -ErrorAction Stop
+        $script:dictOut = Import-Ini -Path "$tempFolder/output.ini" -ErrorAction Stop
+    }
+    AfterAll {
+        Remove-Item "$tempFolder/output.ini"
     }
 
     It "content matches original hashtable" {


### PR DESCRIPTION
This allows a string representation of a ini file to be imported.
This can be useful when the file is read from a web request.

In order to implement this, a slight performance buff was implemented:
files are now read with `[System.IO.File]::ReadAllLines()` instead for `switch -file`
Read more: https://devdojo.com/hcritter/powershell-performance-test-file-reading

closes #62, closes #71


<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have added Pester Tests that describe what my changes should do.
- [x] I have updated the documentation accordingly.
