### PR TITLE
Aligned `Export-Ini` behaviour with ps native commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,7 @@ Details on how to upgrade are documented in the [Migrating to PSIni v4](#TODO: )
 
 ### Changed
 
-* ***BREAKING**: `Get-IniContent` is replaced with `Import-Ini` @lipkau
-* ***BREAKING**: `Out-IniFile` is replaced with `Export-Ini` @lipkau
+* **BREAKING**: Changed `Export-Ini` parameters to match the behaviour of other `Export-*` functions @lipkau #118
 
 ### Removed
 

--- a/Tests/PsIni.Integration.Tests.ps1
+++ b/Tests/PsIni.Integration.Tests.ps1
@@ -22,7 +22,7 @@ Describe "PSIni integration tests" -Tag "Integration" {
         }
     }
     BeforeEach {
-        Export-Ini -InputObject $dictIn -Path "$tempFolder/output.ini" -Force -ErrorAction Stop
+        Export-Ini -InputObject $dictIn -Path "$tempFolder/output.ini" -ErrorAction Stop
         $script:dictOut = Import-Ini -Path "$tempFolder/output.ini" -ErrorAction Stop
     }
     AfterAll {


### PR DESCRIPTION
_`Export-Csv` was used as reference._
Changes include:
* added `SupportsShouldProcess` for `-Confirm` and `Whatif`
* added `-LiteralPath` parameter to support files with special chars
* added aliases to parameters
* added `-NoClobber` parameter
* removed `-Passthru`

### Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have added Pester Tests that describe what my changes should do.
- [x] I have updated the documentation accordingly.
